### PR TITLE
SS-26: Confluence setup in manifest file

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -14,6 +14,10 @@ modules:
       function: resolver
       events:
         - avi:jira:updated:issue
+    - key: sprint-closed-trigger
+      function: resolver
+      events:
+        - avi:jira:sprint:closed
   jira:issuePanel:
     - key: accessibility-checklist-panel
       resource: main
@@ -52,10 +56,16 @@ permissions:
     scripts:
       - unsafe-inline
   scopes:
-    - "read:jira-work"
-    - "write:jira-work"
-    - "read:jira-user"
-    - "storage:app"
+    - 'read:jira-work'
+    - 'write:jira-work' 
+    - 'read:jira-user'
+    - 'storage:app'
+    - 'write:confluence-content'
+    - 'read:confluence-space.summary'
+    - 'read:confluence-content.summary'
+    - 'read:confluence-user'
+    - 'write:page:confluence'
+    - 'read:space:confluence'
 app:
   runtime:
     name: nodejs22.x


### PR DESCRIPTION
Problem Statement:
Confluence not set up in the Forge application.

Proposed Solution:
Update the scopes to include Confluence permissions & register the sprint closed event to trigger the sprint sustainability report generation.